### PR TITLE
Handle serialization of bool and int values

### DIFF
--- a/jprops.py
+++ b/jprops.py
@@ -62,7 +62,7 @@ def write_property(fh, key, value):
   """
   fh.write(_escape_key(key))
   fh.write('=')
-  fh.write(_escape_value(value))
+  fh.write(_escape_value(_stringify_value(value)))
   fh.write('\n')
 
 
@@ -167,6 +167,18 @@ def _escape(value, chars=''):
   value = re.sub(u'[\u0000-\u0019\u007f-\uffff]', _unicode_replace, value)
 
   return value.encode('latin-1')
+
+
+def _stringify_value(value):
+  if value is True:
+    return 'true'
+  if value is False:
+    return 'false'
+  if isinstance(value, (int, float)):
+    return str(value)
+  if isinstance(value, basestring):
+    return value
+  raise ValueError('Cannot encode value %r of type %s.' % (value, type(value)))
 
 
 def _unicode_replace(m):

--- a/test_jprops.py
+++ b/test_jprops.py
@@ -155,6 +155,20 @@ def test_escape_value_leading_whitespace():
   eq_(r'\ \ x\ty ', jprops._escape_value('  x\ty '))
 
 
+def test_stringify_value_handles_bools():
+  eq_('true', jprops._stringify_value(True))
+  eq_('false', jprops._stringify_value(False))
+
+
+def test_stringify_value_handles_numbers():
+  eq_('42', jprops._stringify_value(42))
+  eq_('2.25', jprops._stringify_value(2.25))
+
+def test_stringify_value_leaves_strings_alone():
+  eq_(u'\u00ff', jprops._stringify_value(u'\u00ff'))
+  eq_('string', jprops._stringify_value('string'))
+
+
 def test_escape_keys():
   eq_(r'\=', jprops._escape_key('='))
   eq_(r'\:', jprops._escape_key(':'))


### PR DESCRIPTION
It is sometimes useful to be able to save props which are in various other
native Python types. Even though we can't and/or don't attempt to detect and
parse bools, ints and floats back into their native types it is still
convenient to be able to save properties which aren't plain strings.
